### PR TITLE
Fix ClientFrame instantiation in MainSwing

### DIFF
--- a/src/main/java/main/java/sandboxbot/MainSwing.java
+++ b/src/main/java/main/java/sandboxbot/MainSwing.java
@@ -10,6 +10,9 @@ public class MainSwing {
         main.java.sandboxbot.BotCore bot = new main.java.sandboxbot.BotCore(15, world);
         bot.register(new RandomWalker(), true);
 
-        SwingUtilities.invokeLater(() -> new ClientFrame(bot, world, 40, 30));
+        SwingUtilities.invokeLater(() -> {
+            ClientFrame frame = new ClientFrame();
+            frame.setVisible(true);
+        });
     }
 }


### PR DESCRIPTION
## Summary
- Ensure `MainSwing` uses the no-argument `ClientFrame` constructor and displays the window.

## Testing
- `javac -d out $(find src/main/java -name "*.java")`


------
https://chatgpt.com/codex/tasks/task_e_68a3a434d16c83308dd0a1fed485aaf7