### PR TITLE
Add Java GUI client launcher with hideable plugin list

### DIFF
--- a/ClientLauncher.java
+++ b/ClientLauncher.java
@@ -1,0 +1,78 @@
+import javax.swing.*;
+import java.awt.*;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class ClientLauncher {
+    private static final File BASE_DIR = new File(System.getProperty("user.dir"));
+
+    private static String resolveJavaCmd() {
+        File bundled = new File(BASE_DIR, "jre/bin/java");
+        return bundled.exists() ? bundled.getPath() : "java";
+    }
+
+    private static String[] listPlugins() {
+        File dir = new File(BASE_DIR, "plugins");
+        if (dir.isDirectory()) {
+            String[] names = dir.list();
+            if (names != null) {
+                Arrays.sort(names);
+                return names;
+            }
+        }
+        return new String[0];
+    }
+
+    private static void launchPokemmo() {
+        String java = resolveJavaCmd();
+        File classPath = new File(BASE_DIR, "PokeMMO.exe");
+        ProcessBuilder pb = new ProcessBuilder(
+                java,
+                "-Xmx384M",
+                "-Dfile.encoding=UTF-8",
+                "-cp",
+                classPath.getPath(),
+                "com.pokeemu.client.Client"
+        );
+        pb.directory(BASE_DIR);
+        try {
+            pb.start();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(() -> {
+            JFrame frame = new JFrame("PokeMMO Launcher");
+            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+            frame.setLayout(new BorderLayout());
+
+            JPanel pluginPanel = new JPanel(new BorderLayout());
+            pluginPanel.setBorder(BorderFactory.createTitledBorder("Plugins"));
+            JList<String> pluginList = new JList<>(listPlugins());
+            pluginPanel.add(new JScrollPane(pluginList), BorderLayout.CENTER);
+
+            JPanel mainPanel = new JPanel();
+            JButton launchBtn = new JButton("Launch PokeMMO");
+            launchBtn.addActionListener(e -> launchPokemmo());
+            mainPanel.add(launchBtn);
+
+            JButton toggleBtn = new JButton("Hide Plugins");
+            toggleBtn.addActionListener(e -> {
+                boolean visible = pluginPanel.isVisible();
+                pluginPanel.setVisible(!visible);
+                toggleBtn.setText(visible ? "Show Plugins" : "Hide Plugins");
+                frame.revalidate();
+            });
+            mainPanel.add(toggleBtn);
+
+            frame.add(pluginPanel, BorderLayout.WEST);
+            frame.add(mainPanel, BorderLayout.CENTER);
+            frame.pack();
+            frame.setLocationRelativeTo(null);
+            frame.setVisible(true);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- replace Python launcher with Java Swing application
- list plugins and toggle plugin panel visibility
- start PokeMMO via ProcessBuilder using bundled or system Java

## Testing
- `javac ClientLauncher.java`


------
https://chatgpt.com/codex/tasks/task_e_68a3bbc4456c8330b0650eac5e1413be