### PR TITLE
Open game in new window with plugin list

### DIFF
--- a/ClientLauncher.java
+++ b/ClientLauncher.java
@@ -1,0 +1,100 @@
+import javax.swing.*;
+import java.awt.*;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class ClientLauncher {
+    private static final File BASE_DIR = new File(System.getProperty("user.dir"));
+
+    private static String resolveJavaCmd() {
+        File bundled = new File(BASE_DIR, "jre/bin/java");
+        return bundled.exists() ? bundled.getPath() : "java";
+    }
+
+    private static String[] listPlugins() {
+        File dir = new File(BASE_DIR, "plugins");
+        if (dir.isDirectory()) {
+            String[] names = dir.list();
+            if (names != null) {
+                Arrays.sort(names);
+                return names;
+            }
+        }
+        return new String[0];
+    }
+
+    private static JPanel buildPluginPanel() {
+        JPanel pluginPanel = new JPanel(new BorderLayout());
+        pluginPanel.setBorder(BorderFactory.createTitledBorder("Plugins"));
+        JList<String> pluginList = new JList<>(listPlugins());
+        pluginPanel.add(new JScrollPane(pluginList), BorderLayout.CENTER);
+        return pluginPanel;
+    }
+
+    private static void launchPokemmo() {
+        String java = resolveJavaCmd();
+        File classPath = new File(BASE_DIR, "PokeMMO.exe");
+        ProcessBuilder pb = new ProcessBuilder(
+                java,
+                "-Xmx384M",
+                "-Dfile.encoding=UTF-8",
+                "-cp",
+                classPath.getPath(),
+                "com.pokeemu.client.Client"
+        );
+        pb.directory(BASE_DIR);
+        try {
+            pb.start();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void openGameWindow() {
+        JFrame gameFrame = new JFrame("PokeMMO");
+        gameFrame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+        gameFrame.setLayout(new BorderLayout());
+
+        JPanel pluginPanel = buildPluginPanel();
+        JPanel gamePanel = new JPanel(new BorderLayout());
+        gamePanel.setBorder(BorderFactory.createTitledBorder("Game"));
+        gamePanel.add(new JLabel("PokeMMO running...", SwingConstants.CENTER), BorderLayout.CENTER);
+
+        JButton toggleBtn = new JButton("Hide Plugins");
+        toggleBtn.addActionListener(e -> {
+            boolean visible = pluginPanel.isVisible();
+            pluginPanel.setVisible(!visible);
+            toggleBtn.setText(visible ? "Show Plugins" : "Hide Plugins");
+            gameFrame.revalidate();
+        });
+
+        gameFrame.add(pluginPanel, BorderLayout.WEST);
+        gameFrame.add(gamePanel, BorderLayout.CENTER);
+        gameFrame.add(toggleBtn, BorderLayout.SOUTH);
+
+        gameFrame.setSize(800, 600);
+        gameFrame.setLocationRelativeTo(null);
+        gameFrame.setVisible(true);
+
+        launchPokemmo();
+    }
+
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(() -> {
+            JFrame frame = new JFrame("PokeMMO Launcher");
+            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+
+            JButton launchButton = new JButton("Launch PokeMMO");
+            launchButton.addActionListener(e -> {
+                frame.dispose();
+                openGameWindow();
+            });
+            frame.add(launchButton);
+
+            frame.pack();
+            frame.setLocationRelativeTo(null);
+            frame.setVisible(true);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Launch button now opens a dedicated window that lists plugins
- Started game process after window opens and added toggle to hide plugins
- Renamed the launch button variable to avoid duplicate declaration

## Testing
- `javac ClientLauncher.java`
- `java ClientLauncher` *(fails: java.awt.HeadlessException)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bbc4456c8330b0650eac5e1413be