### PR TITLE
Fix launcher blocking game startup

### DIFF
--- a/ClientLauncher.java
+++ b/ClientLauncher.java
@@ -140,7 +140,21 @@ public class ClientLauncher {
                     Process proc = pb.start();
                     long pid = proc.pid();
                     LOGGER.info("Started PokeMMO with pid " + pid);
-                    PidEmbedder.reparent(pid, hostFrame);
+
+                    // Attempt to embed the client window without blocking its startup.
+                    // Running the embedder asynchronously prevents the launcher from
+                    // hanging until it is closed before the game becomes visible.
+                    new Thread(new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                Thread.sleep(2000);
+                            } catch (InterruptedException ignored) {
+                            }
+                            PidEmbedder.reparent(pid, hostFrame);
+                        }
+                    }).start();
+
                     proc.waitFor();
                 } catch (Exception e) {
                     LOGGER.log(Level.SEVERE, "Failed to launch PokeMMO", e);


### PR DESCRIPTION
## Summary
- Launch PokeMMO client without blocking on window embedding
- Embed client window asynchronously to keep launcher responsive

## Testing
- `javac ClientLauncher.java PidEmbedder.java plugins/Plugin.java`


------
https://chatgpt.com/codex/tasks/task_e_68a3eb9f6b9083309476f84b29ab1083