### PR TITLE
Fix launcher blocking game startup

### DIFF
--- a/ClientLauncher.java
+++ b/ClientLauncher.java
@@ -28,6 +28,7 @@ import plugins.Plugin;
 public class ClientLauncher {
     private static final File BASE_DIR = new File(System.getProperty("user.dir"));
     private static final Logger LOGGER = Logger.getLogger(ClientLauncher.class.getName());
+    private static final String CLIENT_WINDOW_TITLE = "PokeMMO";
     private static JTextArea logArea;
 
     static {
@@ -140,7 +141,21 @@ public class ClientLauncher {
                     Process proc = pb.start();
                     long pid = proc.pid();
                     LOGGER.info("Started PokeMMO with pid " + pid);
-                    PidEmbedder.reparent(pid, hostFrame);
+
+                    // Attempt to embed the client window without blocking its startup.
+                    // Running the embedder asynchronously prevents the launcher from
+                    // hanging until it is closed before the game becomes visible.
+                    new Thread(new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                Thread.sleep(2000);
+                            } catch (InterruptedException ignored) {
+                            }
+                            PidEmbedder.reparent(CLIENT_WINDOW_TITLE, hostFrame);
+                        }
+                    }).start();
+
                     proc.waitFor();
                 } catch (Exception e) {
                     LOGGER.log(Level.SEVERE, "Failed to launch PokeMMO", e);

--- a/PidEmbedder.java
+++ b/PidEmbedder.java
@@ -9,8 +9,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Utility class that attempts to reparent a game window into the launcher
- * using the process ID of the spawned client. The implementation relies on
+ * Utility class that attempts to reparent a game window into the launcher.
+ * PID based embedding proved unreliable on some systems, so this helper now
+ * locates the client window by its title. The implementation relies on
  * external command line tools such as {@code xdotool} on X11 systems. When
  * these tools are unavailable the method will simply log a warning and return
  * without affecting the running client.
@@ -22,16 +23,17 @@ public final class PidEmbedder {
     }
 
     /**
-     * Attempt to reparent the window owned by {@code pid} into {@code host}.
-     * Currently implemented for Linux/X11 via the {@code xdotool} command.
+     * Attempt to reparent the window matching {@code windowName} into
+     * {@code host}. Currently implemented for Linux/X11 via the
+     * {@code xdotool} command.
      *
-     * @param pid  process identifier of the game client
-     * @param host host frame to embed the game window into
+     * @param windowName title of the game client window
+     * @param host       host frame to embed the game window into
      */
-    public static void reparent(long pid, JFrame host) {
+    public static void reparent(String windowName, JFrame host) {
         String os = System.getProperty("os.name").toLowerCase();
         if (!os.contains("linux")) {
-            LOGGER.warning("PID based embedding is only supported on Linux with xdotool");
+            LOGGER.warning("Window embedding is only supported on Linux with xdotool");
             return;
         }
 
@@ -42,19 +44,19 @@ public final class PidEmbedder {
                 return;
             }
 
-            Process search = new ProcessBuilder("xdotool", "search", "--pid", Long.toString(pid)).start();
-            BufferedReader br = new BufferedReader(new InputStreamReader(search.getInputStream()));
-            String childId = br.readLine();
-            search.waitFor();
+            String childId = queryWindowId("^" + windowName + "$");
             if (childId == null || childId.isEmpty()) {
-                LOGGER.warning("No window found for pid " + pid);
+                LOGGER.warning("No window found matching title " + windowName);
                 return;
             }
 
             new ProcessBuilder("xdotool", "windowreparent", childId.trim(), hostId.trim()).start().waitFor();
-            LOGGER.info("Reparented game window " + childId.trim() + " into launcher");
+            // Ensure the window becomes visible immediately after reparenting.
+            new ProcessBuilder("xdotool", "windowmap", childId.trim()).start().waitFor();
+            new ProcessBuilder("xdotool", "windowraise", childId.trim()).start().waitFor();
+            LOGGER.info("Reparented game window " + childId.trim() + " into launcher and mapped");
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Failed to embed window via pid", e);
+            LOGGER.log(Level.WARNING, "Failed to embed window by name", e);
         }
     }
 


### PR DESCRIPTION
## Summary
- Launch PokeMMO client without blocking on window embedding
- Embed client window asynchronously to keep launcher responsive
- Map and raise embedded window so the game appears immediately
- Find client window by title instead of PID for more reliable embedding
- Centralize the client window title in a constant for reuse

## Testing
- `javac ClientLauncher.java PidEmbedder.java plugins/Plugin.java`


------
https://chatgpt.com/codex/tasks/task_e_68a3eb9f6b9083309476f84b29ab1083