### PR TITLE
Reformat launcher logging output and document usage

### DIFF
--- a/ClientLauncher.java
+++ b/ClientLauncher.java
@@ -28,10 +28,16 @@ import plugins.Plugin;
 public class ClientLauncher {
     private static final File BASE_DIR = new File(System.getProperty("user.dir"));
     private static final Logger LOGGER = Logger.getLogger(ClientLauncher.class.getName());
+    private static final String CLIENT_WINDOW_TITLE = "PokeMMO";
     private static JTextArea logArea;
 
     static {
         try {
+            System.setProperty("java.util.logging.SimpleFormatter.format", "%1$tT %4$s: %5$s%6$s%n");
+            Logger rootLogger = Logger.getLogger("");
+            for (Handler h : rootLogger.getHandlers()) {
+                h.setFormatter(new SimpleFormatter());
+            }
             FileHandler handler = new FileHandler(new File(BASE_DIR, "launcher.log").getAbsolutePath(), true);
             handler.setFormatter(new SimpleFormatter());
             LOGGER.addHandler(handler);
@@ -138,9 +144,23 @@ public class ClientLauncher {
                     }
                     pb.directory(BASE_DIR);
                     Process proc = pb.start();
-                    long pid = proc.pid();
-                    LOGGER.info("Started PokeMMO with pid " + pid);
-                    PidEmbedder.reparent(pid, hostFrame);
+                    LOGGER.info("Started PokeMMO with pid " + proc.pid());
+
+                    // Attempt to embed the client window without blocking its startup.
+                    // Running the embedder asynchronously prevents the launcher from
+                    // hanging until it is closed before the game becomes visible.
+                    new Thread(new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                Thread.sleep(2000);
+                            } catch (InterruptedException ignored) {
+                            }
+                            // Embed the client by its window title rather than PID
+                            PidEmbedder.reparent(CLIENT_WINDOW_TITLE, hostFrame);
+                        }
+                    }).start();
+
                     proc.waitFor();
                 } catch (Exception e) {
                     LOGGER.log(Level.SEVERE, "Failed to launch PokeMMO", e);

--- a/PidEmbedder.java
+++ b/PidEmbedder.java
@@ -9,8 +9,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Utility class that attempts to reparent a game window into the launcher
- * using the process ID of the spawned client. The implementation relies on
+ * Utility class that attempts to reparent a game window into the launcher.
+ * PID based embedding proved unreliable on some systems, so this helper now
+ * locates the client window by its title. The implementation relies on
  * external command line tools such as {@code xdotool} on X11 systems. When
  * these tools are unavailable the method will simply log a warning and return
  * without affecting the running client.
@@ -22,16 +23,17 @@ public final class PidEmbedder {
     }
 
     /**
-     * Attempt to reparent the window owned by {@code pid} into {@code host}.
-     * Currently implemented for Linux/X11 via the {@code xdotool} command.
+     * Attempt to reparent the window matching {@code windowName} into
+     * {@code host}. Currently implemented for Linux/X11 via the
+     * {@code xdotool} command.
      *
-     * @param pid  process identifier of the game client
-     * @param host host frame to embed the game window into
+     * @param windowName title of the game client window
+     * @param host       host frame to embed the game window into
      */
-    public static void reparent(long pid, JFrame host) {
+    public static void reparent(String windowName, JFrame host) {
         String os = System.getProperty("os.name").toLowerCase();
         if (!os.contains("linux")) {
-            LOGGER.warning("PID based embedding is only supported on Linux with xdotool");
+            LOGGER.warning("Window embedding is only supported on Linux with xdotool");
             return;
         }
 
@@ -42,19 +44,19 @@ public final class PidEmbedder {
                 return;
             }
 
-            Process search = new ProcessBuilder("xdotool", "search", "--pid", Long.toString(pid)).start();
-            BufferedReader br = new BufferedReader(new InputStreamReader(search.getInputStream()));
-            String childId = br.readLine();
-            search.waitFor();
+            String childId = queryWindowId("^" + windowName + "$");
             if (childId == null || childId.isEmpty()) {
-                LOGGER.warning("No window found for pid " + pid);
+                LOGGER.warning("No window found matching title " + windowName);
                 return;
             }
 
             new ProcessBuilder("xdotool", "windowreparent", childId.trim(), hostId.trim()).start().waitFor();
-            LOGGER.info("Reparented game window " + childId.trim() + " into launcher");
+            // Ensure the window becomes visible immediately after reparenting.
+            new ProcessBuilder("xdotool", "windowmap", childId.trim()).start().waitFor();
+            new ProcessBuilder("xdotool", "windowraise", childId.trim()).start().waitFor();
+            LOGGER.info("Reparented game window " + childId.trim() + " into launcher and mapped");
         } catch (Exception e) {
-            LOGGER.log(Level.WARNING, "Failed to embed window via pid", e);
+            LOGGER.log(Level.WARNING, "Failed to embed window by name", e);
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# PokeMMO Launcher
+
+This project provides a Java-based launcher for the PokeMMO client. It embeds the game's window inside a Swing `JFrame` and exposes a simple plugin system.
+
+## Features
+- Lists and toggles plugins discovered via Java's `ServiceLoader`.
+- Logs to `launcher.log` and a text area in the UI using a concise time/level format.
+- On Linux systems with [xdotool](https://www.semicomplete.com/projects/xdotool/) installed, the launcher attempts to reparent the PokeMMO client window into the launcher frame.
+
+## Requirements
+- Java 11 or later (uses `Process.pid()` and `ServiceLoader`).
+- PokeMMO client files (`PokeMMO.exe` on Windows or `PokeMMO.sh` on Linux) must reside in the project directory.
+- Linux users who want the client embedded must have `xdotool` available in `PATH`.
+
+## Building
+Compile the launcher and plugin interface:
+
+```bash
+javac ClientLauncher.java PidEmbedder.java plugins/Plugin.java
+```
+
+## Running
+Start the launcher with:
+
+```bash
+java ClientLauncher
+```
+
+The launcher window displays available plugins on the left and logs at the bottom. When the PokeMMO client starts, its window is reparented into the launcher (on supported systems) after a short delay.
+
+## Plugin Development
+Plugins implement `plugins.Plugin` and are discovered via the standard Java service provider mechanism. Ensure your plugin jar contains a `META-INF/services/plugins.Plugin` file listing its implementation class.
+


### PR DESCRIPTION
## Summary
- Simplified log format and ensured embedding uses window title
- Documented build/run steps and plugin system in README

## Testing
- `javac ClientLauncher.java PidEmbedder.java plugins/Plugin.java`


------
https://chatgpt.com/codex/tasks/task_e_68a3eb9f6b9083309476f84b29ab1083